### PR TITLE
chore(parity): align OffsetSettings default with upstream bias refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusion-ahrs"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 authors = ["Wil Boayue <wil@wsbsolutions.com>"]
 description = "A Rust port of the C library by xioTechnologies, providing memory safety and zero-cost abstractions while maintaining the same performance characteristics."

--- a/src/types.rs
+++ b/src/types.rs
@@ -241,7 +241,7 @@ pub struct OffsetSettings {
     /// Used to compute the filter coefficient as `2π × cutoff_frequency / sample_rate`.
     /// Lower values provide more stability but slower convergence.
     pub cutoff_frequency: f32,
-    /// Timeout period in seconds before offset estimation begins (default 5.0)
+    /// Timeout period in seconds before offset estimation begins (default 3.0)
     ///
     /// Duration the sensor must remain stationary before offset
     /// correction begins. Longer timeouts reduce false corrections.
@@ -257,7 +257,7 @@ impl Default for OffsetSettings {
     fn default() -> Self {
         Self {
             cutoff_frequency: 0.02,
-            timeout: 5.0,
+            timeout: 3.0,
             threshold: 3.0,
         }
     }


### PR DESCRIPTION
## Summary

- Bumps `fusion-c` submodule `b607fc3 → bce206d` (one year of upstream changes).
- Mirrors the only behavioral parity hit from that range: upstream commit `45812d9` (Refactor bias algorithm) lowered the default stationary period from 5 s to 3 s. Updates `OffsetSettings::default().timeout` from `5.0 → 3.0`.
- Bumps crate to `0.5.0` because the `Default` for a public type changes.

## Why nothing else from upstream needed porting

| Upstream | Verdict |
|---|---|
| `955cb25` Fix gravity for ENU and NED | Already correct. Our `gravity()` (`src/ahrs.rs:571`) calls the convention-aware `calculate_half_gravity()`; we never had C's NWU-only hardcoded formula in the public getter. |
| `1512d7d` Fix gravity reset when algorithm reset | N/A. Resets the cached `halfGravity` field added in `955cb25`. We don't cache half-gravity, so there is nothing to reset. |
| Other ~20 upstream commits | Renames, formatting, comment tweaks, Python wrapper changes. No algorithm impact. |

## User-visible impact

A user on default `OffsetSettings` will see offset estimation begin 2 s sooner after the device first becomes stationary. Users who set `timeout` explicitly are unaffected.

## Test plan

- [x] `cargo test` — 91 unit/integration + 35 doctests pass
- [x] `cargo clippy --all-targets --no-deps` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build --no-default-features` — no_std build clean
