### PR TITLE
C-parity fixes, compass DRY, README/CLAUDE/MSRV tightening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,9 +5,11 @@ Rust port of the Fusion AHRS C library, maintaining algorithm parity while follo
 ## Quick Reference
 
 ```bash
+git submodule update --init         # required for C parity tests (pulls fusion-c/)
 cargo test                          # run all tests
 cargo fmt                           # format (required before commit)
 cargo clippy                        # lint
+cargo doc --no-deps                 # build rustdoc for public API
 cargo bench                         # criterion benchmarks (ahrs_benchmarks)
 cargo run --example simple          # basic 6-DOF usage with plots
 cargo run --example advanced        # full 9-DOF with offset & diagnostics
@@ -17,7 +19,7 @@ cargo run --example advanced        # full 9-DOF with offset & diagnostics
 
 - **Input**: Gyroscope, accelerometer, magnetometer data as `nalgebra::Vector3<f32>`
 - **Output**: Orientation as `nalgebra::UnitQuaternion<f32>`
-- **Compatibility**: `#![no_std]` (edition 2024)
+- **Compatibility**: `#![no_std]` (edition 2024, MSRV 1.85)
 
 ### Source Layout
 
@@ -38,11 +40,10 @@ src/
 - Dev only: `csv`, `serde`, `plotters`, `criterion`, `rand`, `rand_pcg`
 - C reference implementation in `fusion-c/` (git submodule — `git submodule update --init`)
 
-### Code Quality Standards
-- **Modularity**: Single-responsibility, minimal public APIs
-- **Performance**: Zero-cost abstractions, minimal allocations
-- **Testability**: Comprehensive unit tests with provided test data
-- **Documentation**: Rustdoc for all public APIs with examples
+### Project-Specific Conventions
+- Extend math behavior through the `Vector3Ext` / `QuaternionExt` traits in `math.rs` rather than free functions
+- Settings types (`AhrsSettings`, `OffsetSettings`) are plain structs constructed directly — no builders
+- All public APIs carry rustdoc with at least one example; doctests should compile
 
 ### Algorithm Features
 - Complementary filter combining high-pass gyroscope + low-pass accel/mag
@@ -59,7 +60,15 @@ src/
 - Use nalgebra types consistently (`Vector3`, `UnitQuaternion`, `Matrix3`)
 - Maintain embedded compatibility: `src/lib.rs` is `#![no_std]` unconditionally — do not introduce `std`-only dependencies or APIs
 - Most modules (`ahrs`, `axes`, `calibration`, `compass`, `math`, `offset`) carry inline unit tests in a `#[cfg(test)] mod tests` block; integration tests live in `tests/`
-- Commit messages follow conventional-commit style: `fix(scope): …`, `docs: …`, `feat(scope): …`, `chore(deps): …`, `fmt: …`
+- Commit messages follow conventional-commit style. Common prefixes: `feat(scope): …`, `fix(scope): …`, `docs: …`, `test: …`, `refactor: …`, `bench: …`, `chore(scope): …` (e.g. `chore(deps)`, `chore(cargo)`, `chore(parity)`). `fmt: …` is the project-specific prefix for pure `cargo fmt` commits
+
+## C Parity Workflow
+Algorithm parity with the upstream C library is enforced via integration tests:
+- `tests/c_parity_tests.rs` — pure-Rust assertions that mirror C behavior on synthetic inputs
+- `tests/c_comparison_test.rs` — runs both implementations on `testdata/sensor_data.csv` and compares outputs (requires `fusion-c/` submodule)
+- `tests/verification_tests.rs` — broader algorithm-behavior checks
+
+When Rust output diverges from C, the C side is authoritative — port the C fix into the Rust implementation rather than adjusting the Rust output. If a deliberate divergence is unavoidable, document it inline and in the PR description.
 
 ## README Maintenance
 Keep `README.md` in sync with the code in the same PR that introduces the change — a stale README is worse than no README.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,6 @@ Rust port of the Fusion AHRS C library, maintaining algorithm parity while follo
 
 ```bash
 cargo test                          # run all tests
-cargo build --no-default-features   # verify no_std / embedded compatibility
 cargo fmt                           # format (required before commit)
 cargo clippy                        # lint
 cargo bench                         # criterion benchmarks (ahrs_benchmarks)
@@ -58,7 +57,7 @@ src/
 ## Development Guidelines
 - Follow the C implementation's algorithm behavior exactly
 - Use nalgebra types consistently (`Vector3`, `UnitQuaternion`, `Matrix3`)
-- Maintain embedded compatibility (`cargo build --no-default-features`)
+- Maintain embedded compatibility: `src/lib.rs` is `#![no_std]` unconditionally — do not introduce `std`-only dependencies or APIs
 - Most modules (`ahrs`, `axes`, `calibration`, `compass`, `math`, `offset`) carry inline unit tests in a `#[cfg(test)] mod tests` block; integration tests live in `tests/`
 - Commit messages follow conventional-commit style: `fix(scope): …`, `docs: …`, `feat(scope): …`, `chore(deps): …`, `fmt: …`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,9 @@
 name = "fusion-ahrs"
 version = "0.5.0"
 edition = "2024"
+rust-version = "1.85"
 authors = ["Wil Boayue <wil@wsbsolutions.com>"]
-description = "A Rust port of the C library by xioTechnologies, providing memory safety and zero-cost abstractions while maintaining the same performance characteristics."
+description = "Rust port of xioTechnologies' Fusion AHRS C library — sensor fusion for gyroscope, accelerometer, and magnetometer with no_std support."
 readme = "README.md"
 homepage = "https://github.com/wboayue/fusion-ahrs/"
 repository = "https://github.com/wboayue/fusion-ahrs/"
@@ -15,6 +16,12 @@ exclude = [
     "justfile",
     "CLAUDE.md",
     "fusion-c",
+    ".github",
+    ".config",
+    ".gitmodules",
+    "testdata",
+    "*.png",
+    "tarpaulin-report.html",
 ]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -37,22 +37,19 @@ The algorithm calculates the orientation as the integration of the gyroscope sum
 ### Basic Example
 
 ```rust
-use fusion_ahrs::{Ahrs, AhrsSettings};
-use nalgebra::{Vector3, UnitQuaternion};
+use fusion_ahrs::Ahrs;
+use nalgebra::Vector3;
 
-// Create AHRS instance
-
-// Option 1: use default settings
+// Option 1: default settings
 let mut ahrs = Ahrs::new();
 
-// Option 2: provide custom settings
-// let settings = AhrsSettings::default();
+// Option 2: custom settings (see "Algorithm Settings" below)
 // let mut ahrs = Ahrs::with_settings(settings);
 
-// Sample sensor data using nalgebra vectors
+// Sample sensor data
 let gyroscope = Vector3::new(0.0, 0.0, 0.0);      // deg/s
 let accelerometer = Vector3::new(0.0, 0.0, 1.0);  // g
-let magnetometer = Vector3::new(1.0, 0.0, 0.0);   // normalized
+let magnetometer = Vector3::new(1.0, 0.0, 0.0);   // µT (or any units; will be normalized)
 
 // Update algorithm (typically called at 100Hz or higher)
 let sample_period = 0.01; // 10ms
@@ -62,9 +59,9 @@ ahrs.update(gyroscope, accelerometer, magnetometer, sample_period);
 let quaternion = ahrs.quaternion();
 let (roll, pitch, yaw) = quaternion.euler_angles();
 
-println!("Roll: {:.1}°, Pitch: {:.1}°, Yaw: {:.1}°", 
-         roll.to_degrees(), 
-         pitch.to_degrees(), 
+println!("Roll: {:.1}°, Pitch: {:.1}°, Yaw: {:.1}°",
+         roll.to_degrees(),
+         pitch.to_degrees(),
          yaw.to_degrees()
 );
 ```
@@ -92,7 +89,10 @@ The magnetic rejection feature reduces the errors that result from temporary mag
 The algorithm provides four outputs: quaternion, gravity, linear acceleration, and Earth acceleration. The quaternion describes the orientation of the sensor relative to the Earth. This can be converted to a rotation matrix using nalgebra's `to_rotation_matrix()` method or to Euler angles using the `euler_angles()` method. Gravity is a direction of gravity in the sensor coordinate frame. Linear acceleration is the accelerometer measurement with gravity removed. Earth acceleration is the accelerometer measurement in the Earth coordinate frame with gravity removed. The algorithm supports North-West-Up (NWU), East-North-Up (ENU), and North-East-Down (NED) axes conventions.
 
 ```rust
+use fusion_ahrs::Ahrs;
 use nalgebra::{Matrix3, Vector3, UnitQuaternion};
+
+let mut ahrs = Ahrs::new();
 
 // Get all algorithm outputs
 let quaternion: UnitQuaternion<f32> = ahrs.quaternion();
@@ -110,7 +110,7 @@ let euler_angles = quaternion.euler_angles(); // (roll, pitch, yaw)
 The AHRS algorithm settings are defined by the `AhrsSettings` struct:
 
 ```rust
-use fusion_ahrs::{AhrsSettings, Convention};
+use fusion_ahrs::{Ahrs, AhrsSettings, Convention};
 
 let settings = AhrsSettings {
     convention: Convention::Nwu,
@@ -138,6 +138,9 @@ let mut ahrs = Ahrs::with_settings(settings);
 The AHRS algorithm internal states can be accessed through the `internal_states()` method:
 
 ```rust
+use fusion_ahrs::Ahrs;
+
+let ahrs = Ahrs::new();
 let states = ahrs.internal_states();
 println!("Acceleration error: {:.1}°", states.acceleration_error);
 println!("Accelerometer ignored: {}", states.accelerometer_ignored);
@@ -157,6 +160,9 @@ println!("Accelerometer ignored: {}", states.accelerometer_ignored);
 The AHRS algorithm flags can be accessed through the `flags()` method:
 
 ```rust
+use fusion_ahrs::Ahrs;
+
+let ahrs = Ahrs::new();
 let flags = ahrs.flags();
 if flags.initialising {
     println!("Algorithm is still initialising");
@@ -258,6 +264,8 @@ All sensor inputs and algorithm outputs use standard nalgebra types:
 ```rust
 use nalgebra::{Vector3, UnitQuaternion, Matrix3};
 use fusion_ahrs::Ahrs;
+
+let ahrs = Ahrs::new();
 
 // All sensor data uses Vector3<f32>
 let gyro_data: Vector3<f32> = Vector3::new(0.1, 0.05, -0.02);

--- a/src/ahrs.rs
+++ b/src/ahrs.rs
@@ -427,14 +427,8 @@ impl Ahrs {
         accelerometer: Vector3<f32>,
         delta_time: f32,
     ) {
-        // Update with zero magnetometer
         self.update(gyroscope, accelerometer, Vector3::zeros(), delta_time);
 
-        // Force magnetometer to be ignored
-        self.magnetometer_ignored = true;
-        self.half_magnetometer_feedback = Vector3::zeros();
-
-        // Zero heading during initialization to prevent drift
         if self.initialising {
             self.set_heading(0.0);
         }

--- a/src/ahrs.rs
+++ b/src/ahrs.rs
@@ -436,7 +436,7 @@ impl Ahrs {
 
         // Zero heading during initialization to prevent drift
         if self.initialising {
-            self.zero_heading();
+            self.set_heading(0.0);
         }
     }
 
@@ -739,13 +739,16 @@ impl Ahrs {
     /// assert!((yaw.to_degrees() - 90.0).abs() < 1.0);
     /// ```
     pub fn set_heading(&mut self, heading: f32) {
-        let heading_rad = heading * DEG_TO_RAD;
-
-        // Extract current roll and pitch
-        let (roll, pitch, _) = self.quaternion.euler_angles();
-
-        // Create new quaternion with same roll/pitch but new heading
-        self.quaternion = UnitQuaternion::from_euler_angles(roll, pitch, heading_rad);
+        let q = self.quaternion.as_ref();
+        let yaw = (q.w * q.k + q.i * q.j).atan2(0.5 - q.j * q.j - q.k * q.k);
+        let half_yaw_minus_heading = 0.5 * (yaw - heading * DEG_TO_RAD);
+        let rotation = UnitQuaternion::from_quaternion(Quaternion::new(
+            half_yaw_minus_heading.cos(),
+            0.0,
+            0.0,
+            -half_yaw_minus_heading.sin(),
+        ));
+        self.quaternion = rotation * self.quaternion;
     }
 
     // Private helper methods
@@ -870,12 +873,6 @@ impl Ahrs {
 
         // Normalize to maintain unit quaternion
         self.quaternion = UnitQuaternion::from_quaternion(new_quaternion);
-    }
-
-    /// Zero the heading while preserving roll and pitch
-    fn zero_heading(&mut self) {
-        let (roll, pitch, _) = self.quaternion.euler_angles();
-        self.quaternion = UnitQuaternion::from_euler_angles(roll, pitch, 0.0);
     }
 }
 

--- a/src/compass.rs
+++ b/src/compass.rs
@@ -1,6 +1,6 @@
 //! Tilt-compensated compass implementation for the Fusion AHRS library
 
-use crate::math::RAD_TO_DEG;
+use crate::math::{RAD_TO_DEG, Vector3Ext};
 use crate::types::Convention;
 use nalgebra::Vector3;
 #[allow(unused_imports)]
@@ -48,64 +48,25 @@ pub fn calculate_heading(
 
 /// Calculate heading for NWU (North-West-Up) convention
 fn calculate_heading_nwu(accelerometer: Vector3<f32>, magnetometer: Vector3<f32>) -> f32 {
-    // Calculate west vector: accel × mag (normalized)
-    let west = safe_normalize(accelerometer.cross(&magnetometer));
-
-    // Calculate north vector: west × accel (normalized)
-    let north = safe_normalize(west.cross(&accelerometer));
-
-    // Calculate heading: atan2(west.x, north.x)
-    let heading_rad = west.x.atan2(north.x);
-
-    heading_rad * RAD_TO_DEG
+    let west = accelerometer.cross(&magnetometer).safe_normalize();
+    let north = west.cross(&accelerometer).safe_normalize();
+    west.x.atan2(north.x) * RAD_TO_DEG
 }
 
 /// Calculate heading for ENU (East-North-Up) convention
 fn calculate_heading_enu(accelerometer: Vector3<f32>, magnetometer: Vector3<f32>) -> f32 {
-    // Calculate west vector: accel × mag (normalized)
-    let west = safe_normalize(accelerometer.cross(&magnetometer));
-
-    // Calculate north vector: west × accel (normalized)
-    let north = safe_normalize(west.cross(&accelerometer));
-
-    // Calculate east vector: -west
+    let west = accelerometer.cross(&magnetometer).safe_normalize();
+    let north = west.cross(&accelerometer).safe_normalize();
     let east = -west;
-
-    // Calculate heading: atan2(north.x, east.x)
-    let heading_rad = north.x.atan2(east.x);
-
-    heading_rad * RAD_TO_DEG
+    north.x.atan2(east.x) * RAD_TO_DEG
 }
 
 /// Calculate heading for NED (North-East-Down) convention
 fn calculate_heading_ned(accelerometer: Vector3<f32>, magnetometer: Vector3<f32>) -> f32 {
-    // Calculate up vector: -accel (inverted gravity)
     let up = -accelerometer;
-
-    // Calculate west vector: up × mag (normalized)
-    let west = safe_normalize(up.cross(&magnetometer));
-
-    // Calculate north vector: west × up (normalized)
-    let north = safe_normalize(west.cross(&up));
-
-    // Calculate heading: atan2(west.x, north.x)
-    let heading_rad = west.x.atan2(north.x);
-
-    heading_rad * RAD_TO_DEG
-}
-
-/// Safely normalize a vector with standard square root for accuracy
-fn safe_normalize(vector: Vector3<f32>) -> Vector3<f32> {
-    let magnitude_squared = vector.magnitude_squared();
-
-    if magnitude_squared == 0.0 {
-        return Vector3::zeros();
-    }
-
-    // Use standard square root for accuracy
-    let magnitude_reciprocal = 1.0 / magnitude_squared.sqrt();
-
-    vector * magnitude_reciprocal
+    let west = up.cross(&magnetometer).safe_normalize();
+    let north = west.cross(&up).safe_normalize();
+    west.x.atan2(north.x) * RAD_TO_DEG
 }
 
 #[cfg(test)]
@@ -266,25 +227,6 @@ mod tests {
     }
 
     #[test]
-    fn test_safe_normalize() {
-        // Test normal vector
-        let v = Vector3::new(3.0, 4.0, 0.0);
-        let normalized = safe_normalize(v);
-        assert!((normalized.magnitude() - 1.0).abs() < 1e-6);
-
-        // Test zero vector
-        let zero = Vector3::zeros();
-        let normalized_zero = safe_normalize(zero);
-        assert_eq!(normalized_zero, Vector3::zeros());
-
-        // Test very small vector
-        let tiny = Vector3::new(1e-10, 1e-10, 1e-10);
-        let normalized_tiny = safe_normalize(tiny);
-        // Should not crash and should produce valid result
-        assert!(normalized_tiny.magnitude() <= 1.0);
-    }
-
-    #[test]
     fn test_compass_heading_range() {
         // Test that headings are in valid range (-180° to +180°)
         let level_accel = Vector3::new(0.0, 0.0, 1.0);
@@ -318,7 +260,7 @@ mod tests {
         assert!((cross.z - 1.0f32).abs() < 1e-6);
 
         // Test normalization preserves direction
-        let normalized = safe_normalize(cross);
+        let normalized = cross.safe_normalize();
         assert!((normalized.z - 1.0f32).abs() < 1e-6);
         assert!((normalized.magnitude() - 1.0f32).abs() < 1e-6);
     }


### PR DESCRIPTION
Bundle of correctness fixes, refactors, and doc/config tightening surfaced during a CLAUDE.md-driven codebase review.

## Correctness — C parity

- **`fix(ahrs)`: port C's `FusionAhrsSetHeading`** (97b425b). The prior implementation decomposed the quaternion via `euler_angles()` and rebuilt with `from_euler_angles(roll, pitch, new_heading)`, which degenerates near pitch ≈ ±90°. C uses direct yaw extraction (`atan2`) and left-multiplies a pure-Z rotation — singularity-free. `zero_heading` was a duplicate of the same broken logic and is now inlined at its sole caller as `set_heading(0.0)`.
- **`fix(ahrs)`: drop redundant overrides in `update_no_magnetometer`** (665b909). The forced `magnetometer_ignored = true` is already set by `update()` when the magnetometer is zero. The forced `half_magnetometer_feedback = zeros` was not present in C and made `internal_states().magnetic_error` diverge after a mag-on → mag-off transition.

## Refactor

- **`refactor(compass)`: use `Vector3Ext::safe_normalize`** (560f050). The private `safe_normalize` in `compass.rs` was a verbatim duplicate of the trait method. Per CLAUDE.md, math extensions live on the trait; the duplicated free function is removed and call sites flow through the trait.

## Docs & config

- **`docs(readme)`: self-contained snippets + magnetometer units** (e30ba4f). Each code block now compiles standalone — dead imports (`AhrsSettings`, `UnitQuaternion`) removed from the basic example, missing `let mut ahrs = Ahrs::new()` setup added to four downstream blocks, and `Ahrs` added to the settings-example import. Magnetometer comment reconciled with the rustdoc ("µT (or any units; will be normalized)").
- **`docs(claude)`: tighten CLAUDE.md** (64f4d4a). Quick Reference gains `git submodule update --init` and `cargo doc --no-deps`; MSRV noted in the architecture block; generic quality standards replaced with project-specific conventions (trait-based math extensions, plain-struct settings, doctest requirement); commit-prefix list broadened; new "C Parity Workflow" section.
- **`chore(cargo)`: pin MSRV, trim excludes, rewrite description** (881032d). `rust-version = "1.85"` pinned; crate metadata refreshed.

## Test plan
- [x] `cargo test --all` — 29 unit + 4 c_comparison + 10 c_parity + 12 verification + 35 doctests, 0 failures
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
