### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-22
+
 ### Changed
-- Bump `nalgebra` requirement from 0.34 to 0.35 (#37).
+- Bump `nalgebra` requirement from 0.34 to 0.35 (#37). `nalgebra` types are part of the public API, so downstream crates must move to 0.35-compatible `Vector3`/`UnitQuaternion`.
 
 ## [0.6.0] - 2026-05-19
 
@@ -92,7 +94,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `#![no_std]` compatibility with nalgebra integration.
 - Simple and advanced examples plus included test data.
 
-[Unreleased]: https://github.com/wboayue/fusion-ahrs/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/wboayue/fusion-ahrs/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/wboayue/fusion-ahrs/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/wboayue/fusion-ahrs/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/wboayue/fusion-ahrs/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/wboayue/fusion-ahrs/compare/v0.4.0...v0.4.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusion-ahrs"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Wil Boayue <wil@wsbsolutions.com>"]


### PR DESCRIPTION
Release v0.7.0.

- Bump crate version 0.6.0 → 0.7.0 (minor, per semver: public-API nalgebra major bump)
- Promote `[Unreleased]` changelog entry to `[0.7.0]`

## Changed
- `nalgebra` requirement 0.34 → 0.35 (#37). Downstream crates must move to 0.35-compatible `Vector3`/`UnitQuaternion`.